### PR TITLE
Remove `ora` package from taskview

### DIFF
--- a/Databases.md
+++ b/Databases.md
@@ -81,9 +81,7 @@ databases within R.
     an open-source parallel database on top of PostgreSQL.
 - The `r pkg("ROracle")` package is a DBI-compliant
   [Oracle database](https://www.oracle.com/database/) driver
-  based on the OCI. The `r pkg("ora")` package provides
-  convenience functions to query and browse a database through the
-  `r pkg("ROracle")` connection.
+  based on the OCI. 
 - Packages for [SQLite](http://www.sqlite.org/), a self-contained,
   high-reliability, embedded, full-featured, public-domain, SQL
   database engine:


### PR DESCRIPTION
The `ora` package was lasted updated in 2014 (2.0-1)

https://cran.r-project.org/src/contrib/Archive/ora/

Archived on 2024-03-04 as email to the maintainer was undeliverable.

Close #28 